### PR TITLE
[TASK] Allow elixir v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-util": "~2.2.0"
   },
   "peerDependencies": {
-    "laravel-elixir": "^3.0"
+    "laravel-elixir": "^4.0"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
As elixir is just a peer-dependency, no error is thrown if
elixir is currently installed in a higher version.

However to be able to shrinkwrap, dependency versions must
match.

This patch raises the allowed elixir version to 4.

I used it with v4 for a while now and it works well.
